### PR TITLE
T004: Setup Azure Verified Modules registry configuration

### DIFF
--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -1,0 +1,10 @@
+{
+  "moduleAliases": {
+    "br": {
+      "public": {
+        "registry": "mcr.microsoft.com",
+        "modulePath": "bicep"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implements T004 by adding bicepconfig.json with AVM registry configuration.

- Added module alias for Azure Verified Modules registry
- Configured br/public registry pointing to mcr.microsoft.com/bicep
- Enables usage of official AVM modules in Bicep templates

Closes #5